### PR TITLE
🏡 Integração de Informações de Endereço no Fluxo de Paciente

### DIFF
--- a/src/main/java/br/com/backend/PsiRizerio/dto/pacienteDTO/PacienteCreateDTO.java
+++ b/src/main/java/br/com/backend/PsiRizerio/dto/pacienteDTO/PacienteCreateDTO.java
@@ -1,5 +1,6 @@
 package br.com.backend.PsiRizerio.dto.pacienteDTO;
 
+import br.com.backend.PsiRizerio.dto.enderecoDTO.EnderecoResponseDTO;
 import br.com.backend.PsiRizerio.dto.planoDTO.PlanoResponseDTO;
 import br.com.backend.PsiRizerio.dto.preferenciaDTO.PreferenciaResponseDTO;
 import br.com.backend.PsiRizerio.enums.StatusUsuario;
@@ -26,4 +27,6 @@ public class PacienteCreateDTO {
     private String senha;
 
     private PlanoResponseDTO fkPlano;
+
+    private EnderecoResponseDTO fkEndereco;
 }

--- a/src/main/java/br/com/backend/PsiRizerio/mapper/PacienteMapper.java
+++ b/src/main/java/br/com/backend/PsiRizerio/mapper/PacienteMapper.java
@@ -6,7 +6,7 @@ import org.mapstruct.Mapper;
 
 import java.util.List;
 
-@Mapper(componentModel = "spring")
+@Mapper(componentModel = "spring", uses = {EnderecoMapper.class})
 public interface PacienteMapper {
     Paciente toEntity(PacienteCreateDTO pacienteCreateDTO);
     Paciente toEntity(PacienteUpdateDTO pacienteUpdateDTO);
@@ -22,6 +22,5 @@ public interface PacienteMapper {
     PacienteSenhaUpdateDTO toDtoUpdateSenha(Paciente paciente);
     PacientePrimeiroLoginDTO toDtoPrimeiroLogin(Paciente paciente);
     PacienteTokenDTO toDtoToken(Paciente paciente, String token);
-
 
 }


### PR DESCRIPTION
# Visão Geral

Este pull request introduz mudanças para integrar informações de endereço (`Endereco`) nos fluxos de criação e atualização de pacientes (`Paciente`). As alterações incluem adicionar uma referência a `Endereco` no DTO de criação de paciente, atualizar o mapper para lidar com a conversão de dados de endereço e modificar o serviço para validar e recuperar dados de endereço.

# Mudanças

## Atualizações de DTO

- [`PacienteCreateDTO`](diffhunk://#diff-e29dcbd895ab4e0ee348abeec2e3842832e8358f915742df46b581fdc70ed68bR3):  
  Adicionado novo campo `fkEndereco` do tipo `EnderecoResponseDTO` para incluir informações de endereço ao criar um paciente.

- [`PacienteCreateDTO`](diffhunk://#diff-e29dcbd895ab4e0ee348abeec2e3842832e8358f915742df46b581fdc70ed68bR30-R31):  
  Atualizado para suportar a integração de informações de endereço.

## Atualizações de Mapper

- **`PacienteMapper`**:  
  Atualizado para utilizar o `EnderecoMapper` para mapear campos relacionados ao endereço, garantindo o tratamento adequado dos dados de `Endereco` durante as conversões de entidade para DTO.

## Atualizações de Serviço

- [`PacienteService`](diffhunk://#diff-8f39320d3ecbefa856f155a04a85f89a07cd3f0aa5e5d91836647e2ef626e94cR10-R12):  
  Adicionado `EnderecoRepository` como dependência para facilitar a busca de endereços.

- [`PacienteService`](diffhunk://#diff-8f39320d3ecbefa856f155a04a85f89a07cd3f0aa5e5d91836647e2ef626e94cR40-R54):  
  Melhorado o método `createUser` para validar e recuperar a entidade `Endereco` com base no ID fornecido em `fkEndereco`, lançando uma exceção caso o endereço não seja encontrado.

- **Método `update`**:  
  Atualizado com lógica semelhante de validação e recuperação para o campo `fkEndereco` durante as atualizações de pacientes.