### PR TITLE
feat: paginação tela de agendamentos por semana

### DIFF
--- a/psiRizerio-services/src/main/java/br/com/backend/PsiRizerio/persistence/repositories/SessaoRepository.java
+++ b/psiRizerio-services/src/main/java/br/com/backend/PsiRizerio/persistence/repositories/SessaoRepository.java
@@ -5,6 +5,8 @@ import br.com.backend.PsiRizerio.dto.sessaoDTO.SessaoKpiResponseDTO;
 import br.com.backend.PsiRizerio.enums.StatusSessao;
 import br.com.backend.PsiRizerio.persistence.entities.Paciente;
 import br.com.backend.PsiRizerio.persistence.entities.Sessao;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -39,6 +41,9 @@ public interface SessaoRepository extends JpaRepository<Sessao, Integer> {
     boolean existsByDataAndHora(LocalDate data, LocalTime hora);
 
     List<Sessao> findByStatusSessao(StatusSessao statusSessao);
+
+    // New: Paginated retrieval of sessions within a date range (e.g., Monday to Friday)
+    Page<Sessao> findByDataBetween(LocalDate inicio, LocalDate fim, Pageable pageable);
 
     @Query("""
             SELECT new br.com.backend.PsiRizerio.dto.sessaoDTO.SessaoKpiResponseDTO(

--- a/psiRizerio-services/src/main/java/br/com/backend/PsiRizerio/service/SessaoService.java
+++ b/psiRizerio-services/src/main/java/br/com/backend/PsiRizerio/service/SessaoService.java
@@ -13,9 +13,11 @@ import br.com.backend.PsiRizerio.persistence.entities.Sessao;
 import br.com.backend.PsiRizerio.persistence.repositories.SessaoRepository;
 import br.com.backend.PsiRizerio.persistence.repositories.PacienteRepository;
 import lombok.RequiredArgsConstructor;
-// Removed unused imports for PageRequest and Pageable
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -162,6 +164,15 @@ public class SessaoService {
         }).toList();
 
         return dtos;
+    }
+
+    // New: weekly sessions (Mon-Fri) with pagination. Expects "monday" to be a Monday date.
+    public Page<Sessao> findSessoesSemana(LocalDate monday, Pageable pageable) {
+        if (monday == null || monday.getDayOfWeek() != DayOfWeek.MONDAY) {
+            throw new EntidadeNaoEncontradaException();
+        }
+        LocalDate friday = monday.plusDays(4);
+        return sessaoRepository.findByDataBetween(monday, friday, pageable);
     }
 
 }


### PR DESCRIPTION
This pull request adds a new paginated API endpoint to list sessions for a specific week (Monday to Friday), along with the necessary repository and service support. The changes introduce pagination and sorting for weekly session queries, making it easier to retrieve and display sessions in a user-friendly, scalable way.

**API enhancements:**

* Added a new `GET /sessao/semana` endpoint in `SessaoController` to retrieve sessions for a given week (Monday to Friday), supporting pagination and sorting by date and time. The endpoint expects the date of a Monday and returns a paginated list of session DTOs.

**Service and repository support:**

* Implemented the `findSessoesSemana` method in `SessaoService` to validate the input date, calculate the date range (Monday to Friday), and delegate the paginated query to the repository.
* Added the `findByDataBetween` method to `SessaoRepository` for paginated retrieval of sessions within a specified date range.

**Dependency and import updates:**

* Imported necessary Spring Data classes (`Page`, `Pageable`, `PageRequest`, `Sort`) and date formatting annotations in relevant files to support the new paginated endpoint and date handling. [[1]](diffhunk://#diff-f77a92aa09af3db63983a8fde4489621526685dbcfc026f879c12eac3e1541c0R15-R19) [[2]](diffhunk://#diff-5d37f677bf954363b27b751280b28bbef6084d7f506a3a22b310504fbbdd25d3R8-R9) [[3]](diffhunk://#diff-a2ce5baad22fba3ea37b854480d5118c9dbba661151fd906bc0f24749c3d7d1aL16-R20)